### PR TITLE
Next.js 보안 패치 적용

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "./deploy.sh"
   },
   "dependencies": {
-    "next": "~15.5.16",
+    "next": "~15.5.18",
     "react": "19.1.7",
     "react-dom": "19.1.7"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       next:
-        specifier: ~15.5.16
+        specifier: ~15.5.18
         version: 15.5.18(react-dom@19.1.7(react@19.1.7))(react@19.1.7)
       react:
         specifier: 19.1.7


### PR DESCRIPTION
## 요약
- Next.js 보안 패치: `next` -> `~15.5.18`
- pnpm lock 기준으로 의존성 갱신

## 배포
- 스크립트: `deploy.sh`
- 위치: `deptno/deployment/deptno-dev`
- 이미지: `harbor.deptno.dev/deptno/deptno-dev:56376ad`
- 검증: rollout 성공, `https://deptno.dev` 200

## 관련 PR
- https://github.com/deptno/deptno.dev/pull/2
- https://github.com/deptno-ai/language-subtitle/pull/16
- https://github.com/deptno/wiki.deptno.dev/pull/28
- https://github.com/deptno/codex-mon/pull/10
- https://github.com/deptno/textube.deptno.dev/pull/5
- https://github.com/deptno/data-kpop/pull/24
- https://github.com/deptno/salji.ro/pull/698